### PR TITLE
The first implementation of the stochastic physics scheme SPPT for MPAS.

### DIFF
--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -22,5 +22,5 @@ ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../physics/physics_mmm -I../stochastic_physics -I../../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -31,7 +31,7 @@ module atm_time_integration
    use mpas_atmphys_driver_microphysics
    use mpas_atmphys_todynamics
    use mpas_atmphys_utilities
-   use stochastic_physics_mpas, only : stochastic_physics_pattern_apply
+   use mpas_stochastic_physics, only : stochastic_physics_pattern_apply
 #endif
 
    use mpas_atm_boundaries, only : nSpecZone, nRelaxZone, nBdyZone, mpas_atm_get_bdy_state, mpas_atm_get_bdy_tend  ! regional_MPAS addition

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -31,6 +31,7 @@ module atm_time_integration
    use mpas_atmphys_driver_microphysics
    use mpas_atmphys_todynamics
    use mpas_atmphys_utilities
+   use stochastic_physics_mpas, only : stochastic_physics_pattern_apply
 #endif
 
    use mpas_atm_boundaries, only : nSpecZone, nRelaxZone, nBdyZone, mpas_atm_get_bdy_state, mpas_atm_get_bdy_tend  ! regional_MPAS addition
@@ -524,6 +525,8 @@ module atm_time_integration
 #endif
 
       real (kind=RKIND)  :: time_dyn_step
+      character(len=32)  :: tend_names(4)
+      integer :: ierr
       logical, parameter :: debug = .false.
 
 
@@ -720,11 +723,24 @@ module atm_time_integration
       call mpas_timer_start('physics_get_tend')
       rk_step = 1
       dynamics_substep = 1
+
+! apply random perturbation pattern to the tendency
+      tend_names(1) = "rucuten"
+      tend_names(2) = "rvcuten"
+      tend_names(3) = "rublten"
+      tend_names(4) = "rvblten"
+      call stochastic_physics_pattern_apply(domain, 4, tend_names, ierr)
+
       call physics_get_tend( block, mesh, state, diag, tend, tend_physics, &
                              block % configs, rk_step, dynamics_substep, &
                              tend_ru_physics, tend_rtheta_physics, tend_rho_physics, &
                              exchange_halo_group )
       call mpas_timer_stop('physics_get_tend')
+
+! apply random perturbation pattern to the tendency
+      tend_names(1) = "tend_rtheta_physics"
+!      tend_names(2) = "tend_rho_physics"
+      call stochastic_physics_pattern_apply(domain, 1, tend_names, ierr)
 #else
 #ifndef MPAS_CAM_DYCORE
       !

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -48,7 +48,7 @@ module atm_core
       use mpas_attlist, only : mpas_modify_att
       use mpas_string_utils, only : mpas_string_replace
       use mpas_atm_halos, only: atm_build_halo_groups, exchange_halo_group
-      use stochastic_physics_mpas, only : stochastic_physics_pattern_init
+      use mpas_stochastic_physics, only : stochastic_physics_pattern_init
 
       implicit none
 
@@ -977,7 +977,7 @@ module atm_core
       use mpas_atmphys_update
 #endif
       use mpas_atm_halos, only: exchange_halo_group
-      use stochastic_physics_mpas, only : stochastic_physics_pattern_adv
+      use mpas_stochastic_physics, only : stochastic_physics_pattern_adv
    
       implicit none
    

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1010,7 +1010,7 @@ module atm_core
       endif
 #endif
 
-      call stochastic_physics_pattern_adv(domain, ierr)
+      call stochastic_physics_pattern_adv(domain, itimestep, ierr)
       call atm_timestep(domain, dt, currTime, itimestep, exchange_halo_group)
 
    end subroutine atm_do_timestep


### PR DESCRIPTION
This implementation adds pattern initialization and advancement calls to the atmos_core module, and pattern application calls to atm_time_integration module.   It also modifies Makefiles in core_atmosphere/ and its subdirectory dynamics/.

The file Registry.xml is also modified to add variables for patterns in Gaussian and icosahedral grid.



